### PR TITLE
Update docs link to react spectrum homepage

### DIFF
--- a/guides/introduction_to_react_spectrum.md
+++ b/guides/introduction_to_react_spectrum.md
@@ -11,4 +11,4 @@ React Spectrum enables accessibility and common behavior to be handled out of th
 
 The sample templates generated through the CLI leverage React Spectrum in the UI as an example. 
 
-To learn more, please visit the React Spectrum GitHub repository: https://github.com/adobe-private/react-spectrum-v3
+To learn more, please visit the React Spectrum Homepage: https://react-spectrum.adobe.com/.


### PR DESCRIPTION
The Github repo says RS is under construction and makes an impression that it's not ready for use. On the other hand the https://react-spectrum.adobe.com/ page looks great, so it should be the entry point for RS.