### PR TITLE
Add app-hooks.md to manifest [REVIEW - DO NOT MERGE UNTIL APPROVED]

### DIFF
--- a/guides.md
+++ b/guides.md
@@ -12,3 +12,4 @@
 * [Deployment Overview](guides/deployment.md)
 * [CI/CD for Firefly Applications](guides/ci_cd_for_firefly_apps.md)
 * [Managing Application Logs](guides/application_logging.md)
+* [Event hooks for Project Firefly Applications](guides/app-hooks.md)

--- a/manifest.json
+++ b/manifest.json
@@ -136,6 +136,12 @@
             "pages": [],
             "path": "AdobeDocs/project-firefly/master/guides/application_logging.md",
             "title": "Managing Application Logs"
+          },
+          {
+            "importedFileName": "app-hooks",
+            "pages": [],
+            "path": "AdobeDocs/project-firefly/master/guides/app-hooks.md",
+            "title": "Event hooks for Project Firefly Applications"
           }
         ]
     },


### PR DESCRIPTION
@sarahxxu related to Issue #46 , added app-hooks.md to the bottom of the Guides section of the docs. Please review and lmk if you prefer this doc to appear in a different order within the Guides section.