### PR TITLE
Add tip for returning large response payload

### DIFF
--- a/guides/tips_tricks.md
+++ b/guides/tips_tricks.md
@@ -24,7 +24,7 @@ When you test this functionality for web action using Postman or web browser wit
 
 ## Returning Large Response Payload
 
-You can return a [response payload of max 1MB](https://github.com/AdobeDocs/adobeio-runtime/blob/master/guides/system_settings.md) in an Adobe I/O Runtime action. That is more than enough for the majority of the use cases we have seen so far. However, if your action would return a larger payload than the 1MB limit, we provide a scalable solution with [Project Firefly Files SDK](https://github.com/adobe/aio-lib-files). It allows you to persist a binary file to the blob storage, obtain a downloadable URL and return an HTTP Redirect response to the file with this URL. Below is a simple code snippet to demonstrate that.
+You can return a [response payload of max 1MB](https://github.com/AdobeDocs/adobeio-runtime/blob/master/guides/system_settings.md) in an Adobe I/O Runtime action. That is more than enough for the majority of the use cases we have seen so far. However, if your action would return a larger payload than the 1MB limit, we provide a scalable solution with [Project Firefly Files SDK](https://github.com/adobe/aio-lib-files). It allows you to [persist a binary file to the blob storage](https://github.com/adobe/aio-lib-files/blob/master/doc/api.md#Files+write), obtain [a temporary downloadable URL](https://github.com/adobe/aio-lib-files/blob/master/doc/api.md#Files+generatePresignURL) and return an [HTTP Redirect response](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302) to the file with this URL. Below is a simple code snippet to demonstrate that.
 
 ```javascript
 const fileLocation = '/private-dir/large-image.png'

--- a/guides/tips_tricks.md
+++ b/guides/tips_tricks.md
@@ -21,3 +21,21 @@ async function main (params) {
 ```
 
 When you test this functionality for web action using Postman or web browser with developer tools opened, make sure that `Cache-Control` is not automatically set for all the requests.
+
+## Returning Large Response Payload
+
+You can return a [response payload of max 1MB](https://github.com/AdobeDocs/adobeio-runtime/blob/master/guides/system_settings.md) in an Adobe I/O Runtime action. That is more than enough for the majority of the use cases we have seen so far. However, if your action would return a larger payload than the 1MB limit, we provide a scalable solution with [Project Firefly Files SDK](https://github.com/adobe/aio-lib-files). It allows you to persist a binary file to the blob storage, obtain a downloadable URL and return an HTTP Redirect response to the file with this URL. Below is a simple code snippet to demonstrate that.
+
+```javascript
+const fileLocation = '/private-dir/large-image.png'
+const files = await Files.init()
+await files.write(fileLocation, fileContent)
+
+// Generate a presigned URL of the file that is valid for 60 seconds only
+const presignUrl = await files.generatePresignURL(fileLocation, { expiryInSeconds: 60 })
+
+return {
+  headers: { location: presignUrl }, 
+  statusCode: 302
+}
+```


### PR DESCRIPTION
This tip is useful for use cases with large response such as server side rendering.