### PR TITLE
Update application state to include action default params

### DIFF
--- a/guides/application_state.md
+++ b/guides/application_state.md
@@ -32,7 +32,7 @@ hello-world:
 
 ### Considerations about security
 
-For authentication with Adobe APIs, you should leverage [Project Firefly security guideline](https://github.com/AdobeDocs/project-firefly/blob/master/guides/security_overview.md) using our supported SDKs. 
+For authentication with Adobe APIs, you should leverage [Project Firefly Security Guideline](https://github.com/AdobeDocs/project-firefly/blob/master/guides/security_overview.md) using our supported SDKs. 
 
 For other 3rd party systems and APIs when provisioning actions with the secrets/passwords is a must, you can then use the default params as demonstrated above. In order to support this use case, all default params are automatically encrypted. They are decrypted just before the action code is executed. Thus, the only time you have access to the decrypted value is while executing the action code.
 

--- a/guides/application_state.md
+++ b/guides/application_state.md
@@ -32,9 +32,9 @@ hello-world:
 
 ### Considerations about security
 
-Many developers use the default params as a mechanism to provision actions with the secrets/passwords needed to authenticate against some other systems (databases, services, APIs).
+For authentication with Adobe APIs, you should leverage [Project Firefly security guideline](https://github.com/AdobeDocs/project-firefly/blob/master/guides/security_overview.md) using our supported SDKs. 
 
-In order to support this use case, all default params are automatically encrypted. They are decrypted just before the action code is executed. Thus, the only time you have access to the decrypted value is while executing the action code.
+For other 3rd party systems and APIs when provisioning actions with the secrets/passwords is a must, you can then use the default params as demonstrated above. In order to support this use case, all default params are automatically encrypted. They are decrypted just before the action code is executed. Thus, the only time you have access to the decrypted value is while executing the action code.
 
 ## State and files persistence at runtime
 

--- a/guides/application_state.md
+++ b/guides/application_state.md
@@ -1,6 +1,44 @@
 # Dealing with Application State
 
-As part of Project Firefly, you will have out-of-the-box access to file storage and to a key-value store. 
+Application state could be a pre-defined variable of your action that is accessible across all invocations, or dynamic values or files uploaded by the web users when the app is running. Project Firefly provides the appropriate tools to handle each of these requirements.
+
+## Default parameters
+
+Sometimes you want to bind the same parameter values for all invocations or you just set default values of your action. In either case, you have two different options: setting params at the action level, or at the package level (so all actions in that package can inherit them). These params are set in the `manifest.yaml` file, as the following example.
+
+```yaml
+hello-world:
+  function: actions/hello/index.js
+  runtime: 'nodejs:12'
+  inputs:
+    name: Joe
+```
+
+In many cases, these variables are different depending on the build environment of the app, such as different tenant names in dev, stage, prod, etc. To make it work seamlessly with Git commits, you could store the real value of the variables in the `.env` file (which is not committed to Git), and reference them in the `manifest.yaml` file.
+
+```bash
+# in .env
+NAME=Joe
+```
+
+```yaml
+# in manifest.yaml
+hello-world:
+  function: actions/hello/index.js
+  runtime: 'nodejs:12'
+  inputs:
+    name: $NAME
+```
+
+### Considerations about security
+
+Many developers use the default params as a mechanism to provision actions with the secrets/passwords needed to authenticate against some other systems (databases, services, APIs).
+
+In order to support this use case, all default params are automatically encrypted. They are decrypted just before the action code is executed. Thus, the only time you have access to the decrypted value is while executing the action code.
+
+## State and files persistence at runtime
+
+As part of Project Firefly, you will have out-of-the-box access to file storage and to a key-value store. These are particularly useful when you want to persist data dynamically in the individual action invocations.
 
 To provide zero-config state and file caching for Project Firefly, we have created the [Adobe I/O Files library](https://github.com/adobe/aio-lib-files) and [Adobe I/O State library](https://github.com/adobe/aio-lib-state). The Adobe I/O State library is an npm module that provides a JavaScript abstraction on top of distributed/cloud DBs with a simple key-value store state persistence API; whereas the Adobe I/O Files library provides a JavaScript abstraction on top of cloud blob storages with a simple file-system like persistence API.
 


### PR DESCRIPTION
Many users want to define default params for their actions. It is not yet explicitly mentioned in our docs about how to do it.
IMO, default params can be treated as (static) application state, hence creating this PR.