### PR TITLE
Fix to path up 404s

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -176,9 +176,25 @@
       "pages": []
     },
     {
+      "hideNavMenu": true,
+      "description": "Page to avoid 404's coming from old links to this modified events page",
+      "importedFileName": "events-old",
+      "path": "AdobeDocs/project-firefly/master/events.md",
+      "title": "Events old",
+      "pages": []
+    },
+    {
       "importedFileName": "resources",
       "path": "https://adobe.io/apis/experienceplatform/project-firefly/resources.html",
       "title": "Resources",
+      "pages": []
+    },
+    {
+      "hideNavMenu": true,
+      "description": "Page to avoid 404's coming from old links to this modified resource page",
+      "importedFileName": "resources-old",
+      "path": "AdobeDocs/project-firefly/master/resources.md",
+      "title": "Resources old",
       "pages": []
     },
     {


### PR DESCRIPTION
in the new content structure, there are no links to paths for /resources.md or /events.md.  There are links for those items but they are to external sites so old links to AdobeDocs/project-firefly/master/events.md would not resolve in the manifest and be a 404.  By adding the paths in as hidden items allows them to be resolved and not fire 404s. 