### PR TITLE
add step to deploy action before running devtool

### DIFF
--- a/src/pages/resources/asset-compute-worker-ps-api/lesson3.md
+++ b/src/pages/resources/asset-compute-worker-ps-api/lesson3.md
@@ -95,6 +95,10 @@ runtimeManifest:
             require-adobe-auth: true
 ```
 
-Your worker should now be set. Execute the command `aio app run` to test it. In the development tool UI, select an existing or upload a new test image, define the rendition request and click the Run button. You will see the rendition result with a removed background.
+Your worker should now be set. 
+
+Run the `aio app deploy` command to deploy your action to test in the development tool UI.
+
+Then execute the command `aio app run` to test it. In the development tool UI, select an existing or upload a new test image, define the rendition request and click the Run button. You will see the rendition result with a removed background.
 
 There are various options of other photo magics that you can use to enhance your custom worker, such as [Auto Tone](https://adobe.io/apis/creativecloud/photo-imaging-api/api-demo.html?ref=autotone) and [Photoshop actions](https://adobe.io/apis/creativecloud/photo-imaging-api/api-demo.html?ref=psactions). Be creative!


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We have seen the `aio app run` command fail to deploy actions, causing users to hit 404's. As a workaround, run `aio app deploy` first to make sure the action is deployed properly.

## Related Issue

workaround for issue: https://jira.corp.adobe.com/browse/NUI-1639

## Motivation and Context

The action must be deployed in order to be used with the devtool. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
