### PR TITLE
update exc_app learn more links

### DIFF
--- a/src/pages/guides/exc_app/index.md
+++ b/src/pages/guides/exc_app/index.md
@@ -63,26 +63,26 @@ init(runtime => {
 
 Core APIs that let solutions initialize the application, provide access to the runtime object from
 anywhere in the app, listen to events.
-[learn more](./modules/index.md)
+[learn more](https://github.com/AdobeDocs/exc-app/blob/master/docs/modules/root.md)
 
 #### Page
 
 APIs that let solutions interact with the main page and personalize it, e.g. setting the title,
 favicon, refreshing the solution iframe, etc.
-[learn more](./modules/page.md)
+[learn more](https://github.com/AdobeDocs/exc-app/blob/master/docs/modules/page.md)
 
 #### TopBar
 
 APIs that let solutions interact with the top bar and personalize it, e.g. configuring the solution
 area on the left, setting up workspaces, custom search, etc.
-[learn more](./modules/topbar.md)
+[learn more](https://github.com/AdobeDocs/exc-app/blob/master/docs/modules/topbar.md)
 
 #### User
 
 APIs to request user-specific information such as IMS organization, IMS profile, access token,
 tenant, etc. It also  provides solutions with other capabilities such as notifying the shell that
 the session has expired and configuring a logout URL to expire custom sessions.
-[learn more](./modules/user.md)
+[learn more](https://github.com/AdobeDocs/exc-app/blob/master/docs/modules/user.md)
 
 ### Events
 


### PR DESCRIPTION
This pull request proposes updating the `learn more` links in the exc_app index page to point to the documentation in the **exc-app** repository so that users are able to learn how to build their own applications that integrate with Adobe Experience Cloud.  

## Description

Update `learn more` links in the exc_app index page to point to the documentation in the **exc-app** repository.

## Related Issue

Closes https://github.com/AdobeDocs/project-firefly/issues/70

## Motivation and Context

To aid users in building their own applications that integrate with Adobe Experience Cloud.

## How Has This Been Tested?

Links have been tested on the source branch. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
