### PR TITLE
fix link to signature verification doc

### DIFF
--- a/src/pages/resources/events-runtime/index.md
+++ b/src/pages/resources/events-runtime/index.md
@@ -21,7 +21,7 @@ In previous codelab [Consume Events using Journaling API](../journaling-events/i
 ## Benefits of using Runtime Action as Webhook
 
 There are two main benefits to choose runtime action as webhook: 
-- [Built in Signature Verification](/apis/experienceplatform/events/docs.html#!adobedocs/adobeio-events/master/webhook/runtime_webhooks.md#built-in-signature-verification)
+- [Built in Signature Verification](https://developer.adobe.com/events/docs/guides/sdk/sdk_signature_verification/)
 - Tracing actions with Activation Ids 
 
 ## How to choose between Journaling API and Runtime Action webhook


### PR DESCRIPTION
This pull request proposes updating the Runtime Action as a Webhook documentation to point to the Signature Verification section of the I/O Events SDK documentation so that users know how signature verification with I/O Events works. 

## Description

Update Runtime Action as a Webhook documentation to point to Signature Verification section of I/O Events SDK documentation. 

## Related Issue

Closes https://github.com/AdobeDocs/project-firefly/issues/130

## Motivation and Context

To aid users in implementing their own Runtime Actions as Webhooks. 

## How Has This Been Tested?

Links have been tested on the source branch.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
