### PR TITLE
Fix: Use relative link for oauth link

### DIFF
--- a/src/pages/guides/security/understanding_authentication.md
+++ b/src/pages/guides/security/understanding_authentication.md
@@ -10,7 +10,7 @@ keywords:
 
 If you plan to work with Adobe APIs in your custom application, please follow this chapter to understand Adobe Authentication and the libraries that you can leverage. 
 
-Adobe services like Creative SDK, Photoshop, Adobe Analytics, etc. use the OAuth 2.0 protocol for authentication and authorization. Using Adobe OAuth 2.0, you can generate an access token which is used to make API calls from your web server or browser-based apps. You can learn more about it at [OAuth 2.0 Authentication and Authorization](https://developer.adobe.com/developer-console/docs/guides/authentication/OAuth/).
+Adobe services like Creative SDK, Photoshop, Adobe Analytics, etc. use the OAuth 2.0 protocol for authentication and authorization. Using Adobe OAuth 2.0, you can generate an access token which is used to make API calls from your web server or browser-based apps. You can learn more about it at [OAuth 2.0 Authentication and Authorization](/developer-console/docs/guides/authentication/OAuth/).
 
 API services tied to entitled Adobe products (e.g. Campaign, Target, etc.) require a JSON Web Token (JWT) in order to retrieve access tokens for usage against authenticated endpoints. [This document](/developer-console/docs/guides/authentication/JWT/) serves as a quickstart guide for first-time users.
 


### PR DESCRIPTION
Fix oauth link by making it relative.

## Description

## Related Issue

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
